### PR TITLE
build: Change registory to ghcr.io

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
       - main
 
 jobs:
-  lint:
+  push:
     runs-on: ubuntu-latest
     steps:
       - name: Wait for test
@@ -15,17 +15,54 @@ jobs:
           check-name: test
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10
-      - name: Checkout repository
+      - name: Check out the repo
         uses: actions/checkout@v3
-      - name: Start buildx container
-        run: |
-          docker buildx create --use
-          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
         with:
-          username: sevenc7c
-          password: ${{ secrets.DOCKER_TOKEN }}
-      - name: Build image
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Prepare Current Date Arg
+        env:
+          TZ: 'Asia/Tokyo' # タイムゾーン指定
+        run: echo "CURRENT_DATETIME=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
+
+      - name: Prepare Author Name Arg
         run: |
-          docker buildx build --platform linux/amd64,linux/arm64 --push --tag sevenc7c/sonolus-sus-server:latest .
+          echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
+        env:
+          OWNER: '${{ github.repository_owner }}'
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: kirari-bot
+          password: ${{ secrets.KIRARI_TOKEN }}
+
+      - name: Build and push Docker image to GitHub Container Registry
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/${{ env.OWNER_LC }}/sonolus-sus-server:${{ env.CURRENT_DATETIME }},ghcr.io/${{ env.OWNER_LC }}/sonolus-difficulty-server:latest
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.clone_url }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache


### PR DESCRIPTION
## 概要 / Overview
現状DockerHubに各開発者名義でコンテナを公開しているが、利用するとき若干ややこしい。
Github Container Registryであれば PurplePalette名義に統一化できるので、Github Container RegistryにPushするよう変更。

## 詳細 / Details
Dockerコンテナのビルドアクションを追加

## 参考 / References
https://github.com/PurplePalette/sonolus-difficulty-server/blob/develop/.github/workflows/build-container.yml